### PR TITLE
fix item mappings

### DIFF
--- a/src/Plugin/csv/csvItem.php
+++ b/src/Plugin/csv/csvItem.php
@@ -67,8 +67,11 @@ class csvItem {
     if (!$map) {
       $map = $this->getMachinNames();
     }
+
     foreach ($items as $key => $value) {
-      $this->item[$map[$key]] = $value;
+      if (isset($map[$key])) {
+        $this->item[$map[$key]] = strtr($value, ',', '|');
+      }
     }
   }
 


### PR DESCRIPTION
- [x] handle the case when a key is passed which is not in the map
- [x] fix: replace comma with a space if some field contains comma. The comma is field separator, so a comma in a value would mean a new field. The standard way to fix this is to enclose the value (ex.  "Bla, bla"), but unfortunately selfAWB doesn't support it
